### PR TITLE
Added Default level load and Updated Readme for offline loading

### DIFF
--- a/Include/Core/Menu.hpp
+++ b/Include/Core/Menu.hpp
@@ -8,7 +8,7 @@ private:
     void sendLoadLevelMessage();
 
 private:
-    char m_levelInputText[256];
-    char m_inclusionOptionsInputText[256];
+    char m_levelInputText[256] = "_pvz/Levels/Mainstreet/Level_COOP_Mainstreet/Level_COOP_Mainstreet";
+    char m_inclusionOptionsInputText[256] = "GameMode=TeamDeathMatch0;TOD=Day;ZDebugMode=AllLevelLoaded";
 
 };

--- a/README.md
+++ b/README.md
@@ -2,16 +2,23 @@
 Level loader for Plants vs. Zombies: Garden Warfare on PC.
 
 # How to Use It
-Download the latest release and inject it with a DLL injector of your choice (this may be changed at a later point in time). You must be the host and not in the main menu for this to work.
+Download the latest release and inject it with a DLL injector of your choice or copy it into the games install folder named "dinput8.dll".
+You must be the host of a garden ops lobby for the load level button to work.
 
-In the "Level Name" text box, input a LevelData's asset name.
+In the "Level Name" text box, input a LevelData's asset name. (filter by `type:leveldata` in Frosty Editor for Gw1 and copy the file path)
 
-In the "Inclusion Options" text box, input a level's layer inclusion options.
+In the "Inclusion Options" text box, input a level's layer inclusion options. (search for `Description_Win32` in Frosty Editor for Gw1, select the level you entered click Categories->(0)->Mode to see the gamemodes available, may not all work)
 
 ## Example:
 * Level Name: _pvz/Levels/Sandbox/Level_Suburbia2/Level_Suburbia2
 * Inclusion Options: GameMode=RushLarge0;TOD=Day;ZDebugMode=AllLevelLoaded
 
+## How to use Offline
+Without Internet you wont be able to create a garden ops lobby through the menu.
+Add this option to the games launch options on EA app(manage->view properties)->advanced launch options:
+`-GameTime.MaxSimFps -1 -level _pvz/Levels/Desert/Level_COOP_Desert/Level_COOP_Desert -Game.DefaultLayerInclusion GameMode=Coop0`
+Then load into a level using the menu as normal.
+This is also faster than loading manually but wont load your save data so will need a mod to unlock everything.
 # Credits
 PvZ-GW-Map-Loader utilizes the following open source projects:
 * [minhook](https://github.com/TsudaKageyu/minhook)


### PR DESCRIPTION
These arent strictly necessary and you could do thing differently but would be very useful for my use case of testing mods. Could possibly make a default level configurable at some point. (This is still nice even with a list like old map loader to have to do less clicks)
Should be some extra useful information in readme.